### PR TITLE
Add distributed executor test services to example component

### DIFF
--- a/service/example.rest.xml
+++ b/service/example.rest.xml
@@ -81,5 +81,8 @@ along with this software (see the LICENSE.md file). If not, see
         <resource name="scheduleService">
             <method type="post"><service name="moqui.example.ExampleServices.test#ScheduleService"/></method>
         </resource>
+        <resource name="scheduleRealJob">
+            <method type="post"><service name="moqui.example.ExampleServices.test#ScheduleRealJob"/></method>
+        </resource>
     </resource>
 </resource>

--- a/service/example.rest.xml
+++ b/service/example.rest.xml
@@ -77,4 +77,9 @@ along with this software (see the LICENSE.md file). If not, see
             </resource>
         </id>
     </resource>
+    <resource name="test" require-authentication="anonymous-view">
+        <resource name="scheduleService">
+            <method type="post"><service name="moqui.example.ExampleServices.test#ScheduleService"/></method>
+        </resource>
+    </resource>
 </resource>

--- a/service/moqui/example/ExampleServices.xml
+++ b/service/moqui/example/ExampleServices.xml
@@ -215,4 +215,24 @@ along with this software (see the LICENSE.md file). If not, see
             <log level="info" message="HZ Test Echo Service task=${taskName} runtime=${ec.factory.runtimePath} thread=${Thread.currentThread().name}"/>
         </actions>
     </service>
+
+    <service verb="test" noun="ScheduleRealJob" authenticate="false" allow-remote="true">
+        <in-parameters>
+            <parameter name="taskName" default-value="hz-autoapprove-test"/>
+        </in-parameters>
+        <actions>
+            <service-schedule name="moqui.example.ExampleServices.test#RunAutoApproveDistributed"
+                task-name="${taskName}" distribute="true" initial-delay="2000" in-map="[taskName:taskName]"/>
+        </actions>
+    </service>
+    <service verb="test" noun="RunAutoApproveDistributed" authenticate="false">
+        <in-parameters>
+            <parameter name="taskName"/>
+        </in-parameters>
+        <actions>
+            <log level="info" message="[HZ-DIST-JOB] autoApprove#OrdersDelayed task=${taskName} runtime=${ec.factory.runtimePath} thread=${Thread.currentThread().name}"/>
+            <service-call name="mantle.order.OrderServices.autoApprove#OrdersDelayed" ignore-error="true"/>
+            <log level="info" message="[HZ-DIST-JOB] autoApprove#OrdersDelayed completed on runtime=${ec.factory.runtimePath}"/>
+        </actions>
+    </service>
 </services>

--- a/service/moqui/example/ExampleServices.xml
+++ b/service/moqui/example/ExampleServices.xml
@@ -194,4 +194,25 @@ along with this software (see the LICENSE.md file). If not, see
             <auto-parameters entity-name="moqui.example.Example"/>
         </out-parameters>
     </service>
+
+    <!-- ========== Example Scheduled Services ========== -->
+    <service verb="test" noun="ScheduleService" authenticate="false" allow-remote="true">
+        <in-parameters>
+            <parameter name="taskName" default-value="hz-dist-test"/>
+        </in-parameters>
+        <actions>
+            <service-schedule name="moqui.example.ExampleServices.test#Echo"
+                task-name="${taskName}" type="at-fixed-rate" distribute="true" initial-delay="500"
+                polling-interval="200" duration="15000" in-map="[taskName:taskName]"/>
+            <cancel-scheduled-service task-name="${taskName}" cancel-delay="10000"/>
+        </actions>
+    </service>
+    <service verb="test" noun="Echo" authenticate="false">
+        <in-parameters>
+            <parameter name="taskName"/>
+        </in-parameters>
+        <actions>
+            <log level="info" message="HZ Test Echo Service task=${taskName} runtime=${ec.factory.runtimePath} thread=${Thread.currentThread().name}"/>
+        </actions>
+    </service>
 </services>


### PR DESCRIPTION
Adds example services and REST endpoints for validating distributed scheduled execution.

Changes:
- add `test#ScheduleService` and `test#Echo`
- add `test#ScheduleRealJob` and `test#RunAutoApproveDistributed`
- expose test endpoints under `service/example.rest.xml`

Purpose:
- validate distributed scheduling behavior
- validate execution of a real distributed job path